### PR TITLE
Fixed uneditable tags issue with noDefaultTags Flag

### DIFF
--- a/lib/bboxed.js
+++ b/lib/bboxed.js
@@ -271,7 +271,7 @@ function merge() {
 function bboxed(input, options, callback) {
 	var tokens = Lexer.tokenise(input)
 	  , options = merge(bboxed.options, options)
-	  , tags = options.noDefaultTags? {} : bboxed.tags;
+	  , tags = !options.noDefaultTags? merge(require('./tags'), bboxed.tags) : bboxed.tags;
 
 	if (callback || typeof options == 'function') {
 		if (!callback) {
@@ -295,7 +295,7 @@ function bboxed(input, options, callback) {
  * Tags
  */
 
-bboxed.tags = require('./tags');
+bboxed.tags = {};
 
 bboxed.addTag =
 bboxed.addTags = function(tagName, tag) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bboxed",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "An extensible bbcode parser for node.js",
   "homepage": "https://github.com/ackwell/bboxed",
   "main": "lib/bboxed.js",


### PR DESCRIPTION
Couldn't add new tags to empty object, so worked out how to add initial defaults if `noDefaultTags` flag isn't set and merge them with those created in the tags object. 
