### PR TITLE
Update validator package version to fix regex DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "mocha": "~1.16.1",
-    "should": "~2.1.1"
+    "should": "^10.5.0"
   },
   "dependencies": {
     "validator": "~2.0.0"


### PR DESCRIPTION
The version of `validator` in this project is currently `2.0.0`, which has [a DoS vulnerability](https://www.npmjs.com/advisories/42). I've tested the package with `validator` version `10.5.0` which is the latest version and doesn't have the vulnerability, and it works just fine.